### PR TITLE
Setup test suite.

### DIFF
--- a/test/mocha/10-http.js
+++ b/test/mocha/10-http.js
@@ -3,28 +3,40 @@
  */
 'use strict';
 
+const bedrock = require('bedrock');
 const https = require('https');
+const {create} = require('apisauce');
+const {config, util: {uuid}} = bedrock;
 // allow self-signed cert for tests
-const axios = require('axios').create({
-  httpsAgent: new https.Agent({
-    rejectUnauthorized: false
-  })
-});
-const {config} = require('bedrock');
-//const helpers = require('./helpers');
+const httpsAgent = new https.Agent({rejectUnauthorized: false});
+
+const baseURL = `${config.server.baseUri}/kms`;
+const api = create({baseURL});
 
 describe('bedrock-kms-http API', () => {
   describe('operations', () => {
     it('should execute a "generateKey" operation', async () => {
-      let err;
-      try {
-        //await axios.post(...);
-      } catch(e) {
-        err = e;
-      }
-      should.exist(err);
-      should.exist(err.response);
-      err.response.status.should.equal(400);
+      const operation = {
+        '@context': 'https://w3id.org/security/v2',
+        type: 'GenerateKeyOperation',
+        invocationTarget: {
+          id: 'idFoo',
+          type: 'typeFoo',
+          controller: 'controllerFoo',
+        },
+        proof: {
+          type: uuid(),
+          capability: uuid(),
+          created: uuid(),
+          jws: uuid(),
+          proofPurpose: 'capabilityInvocation',
+          verificationMethod: uuid()
+        }
+      };
+      const response = await api.post(`/foo/bar`, operation, {httpsAgent});
+      console.log('ERROR', response.data);
+      // should.exist(err.response);
+      // err.response.status.should.equal(400);
     });
     it('should fail to execute a "generateKey" operation', async () => {
     });

--- a/test/package.json
+++ b/test/package.json
@@ -22,6 +22,7 @@
     "bedrock-permission": "^2.5.0",
     "bedrock-security-context": "^1.0.0",
     "bedrock-server": "^2.3.2",
+    "bedrock-ssm-mongodb": "github:digitalbazaar/bedrock-ssm-mongodb#initial",
     "bedrock-test": "^2.0.0",
     "bedrock-validation": "^4.1.0",
     "uuid": "^3.2.1"

--- a/test/package.json
+++ b/test/package.json
@@ -4,19 +4,23 @@
   "description": "Bedrock KMS HTTP API test",
   "private": true,
   "scripts": {
-    "test": "node --preserve-symlinks test.js Test"
+    "test": "node --preserve-symlinks test.js test"
   },
   "dependencies": {
-    "axios": "^0.18.0",
-    "bedrock": "^1.12.1",
+    "apisauce": "^1.0.2",
+    "bedrock": "^1.15.0",
     "bedrock-account": "^1.0.0",
     "bedrock-did-client": "^1.1.2",
     "bedrock-express": "^2.0.8",
     "bedrock-identity": "^5.0.0",
     "bedrock-key": "^5.1.2",
+    "bedrock-kms": "github:digitalbazaar/bedrock-kms#initial",
+    "bedrock-kms-http": "file:..",
+    "bedrock-mongodb": "^5.5.0",
+    "bedrock-package-manager": "^1.0.0",
     "bedrock-passport": "^4.0.2",
     "bedrock-permission": "^2.5.0",
-    "bedrock-kms-http": "file:..",
+    "bedrock-security-context": "^1.0.0",
     "bedrock-server": "^2.3.2",
     "bedrock-test": "^2.0.0",
     "bedrock-validation": "^4.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
  */
 const bedrock = require('bedrock');
 require('bedrock-kms-http');
+require('bedrock-ssm-mongodb');
 
 require('bedrock-test');
 bedrock.start();


### PR DESCRIPTION
Is a `keyId` intended to be a path (as now) or a full url?  With this test, a keyId is '/kms/foo/bar'

