### PR TITLE
Remove unnecessary zcap authorizations lookup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-kms-http ChangeLog
 
+## 3.0.0 - 2020-09-xx
+
+### Changed
+- **BREAKING**: Do not look up zcaps in authorizations collection;
+  full zcap chain must be submitted. A future feature may involve
+  ensuring that zcaps for certain keys are present in the
+  authorizations collection as an added security measure, but
+  those zcaps would still need to be submitted at invocation.
+
 ## 2.3.0 - 2020-06-30
 
 ### Changed

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -199,23 +199,6 @@ exports.inspectCapabilityChain = async ({
     };
   }
 
-  /* see: https://github.com/digitalbazaar/bedrock-kms-http/issues/23
-  // ensure zcap is in storage if it applies to a patricular key type/flag
-  try {
-    const {authorization: {capability}} =
-      await brZCapStorage.authorizations.get({id});
-    // deep compare capability
-  } catch(e) {
-    if(e.name !== 'NotFoundError') {
-      throw e;
-    }
-    return {
-      valid: false,
-      error: new Error(
-        'One or more capabilities in the chain have not been authorized.')
-    };
-  }*/
-
   return {valid: true};
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -55,7 +55,7 @@ exports.authorize = async ({
 
 // wrap document loader to always generate root zcap from keystore config
 // description in storage
-exports.createCapabilityLoader = ({host, expectedTarget}) => {
+exports.createCapabilityLoader = ({host}) => {
   return async function rootCapabilityLoader(url) {
     const result = exports.getInvocationTarget({host, url});
     if(result) {
@@ -67,21 +67,6 @@ exports.createCapabilityLoader = ({host, expectedTarget}) => {
         document: await exports.generateRootCapability(
           {id: url, target, keystoreId})
       };
-    }
-
-    // see if zcap is in storage
-    try {
-      const {authorization} = await brZCapStorage.authorizations.get(
-        {id: url, invocationTarget: expectedTarget});
-      return {
-        contextUrl: null,
-        documentUrl: url,
-        document: authorization.capability
-      };
-    } catch(e) {
-      if(e.name !== 'NotFoundError') {
-        throw e;
-      }
     }
 
     return defaultDocumentLoader(url);
@@ -213,6 +198,23 @@ exports.inspectCapabilityChain = async ({
         'One or more capabilities in the chain have been revoked.')
     };
   }
+
+  /* see: https://github.com/digitalbazaar/bedrock-kms-http/issues/23
+  // ensure zcap is in storage if it applies to a patricular key type/flag
+  try {
+    const {authorization: {capability}} =
+      await brZCapStorage.authorizations.get({id});
+    // deep compare capability
+  } catch(e) {
+    if(e.name !== 'NotFoundError') {
+      throw e;
+    }
+    return {
+      valid: false,
+      error: new Error(
+        'One or more capabilities in the chain have not been authorized.')
+    };
+  }*/
 
   return {valid: true};
 };

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -25,7 +25,7 @@ exports.createKeystore = async ({
   }
 
   const {httpsAgent} = brHttpsAgent;
-  return await KmsClient.createKeystore({
+  return KmsClient.createKeystore({
     url: `${kmsBaseUrl}/keystores`,
     config,
     httpsAgent,

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -5,6 +5,7 @@
 
 const {config} = require('bedrock');
 const path = require('path');
+require('bedrock-express');
 
 // MongoDB
 config.mongodb.name = 'bedrock_kms_http_test';
@@ -32,3 +33,6 @@ config.karma.config.proxies = {
 config.karma.config.proxyValidateSSL = false;
 config.karma.config.browserNoActivityTimeout = 120000;
 config.karma.config.browserDisconnectTimeout = 120000;
+
+config.express.useSession = false;
+config['https-agent'].keepAlive = true;

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -98,5 +98,5 @@ async function _createKeystore({capabilityAgent, referenceId}) {
   if(referenceId) {
     config.referenceId = referenceId;
   }
-  return await KmsClient.createKeystore({config});
+  return KmsClient.createKeystore({config});
 }


### PR DESCRIPTION
- Configure bedrock-https-agent to use `keepAlive` for tests.