### PR TITLE
Upgrade to bedrock-mongodb 8.

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -22,7 +22,7 @@
     "bedrock-kms": "^3.0.1",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
-    "bedrock-mongodb": "^7.1.0",
+    "bedrock-mongodb": "^8.2.0",
     "bedrock-package-manager": "^1.0.1",
     "bedrock-passport": "^6.0.0",
     "bedrock-permission": "^3.0.0",


### PR DESCRIPTION
Removes the writeConcern deprecation notices from the test project.