### PR TITLE
Implement ipAllowList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-kms-http ChangeLog
 
+## 4.1.0 - TBD
+
+### Added
+- Keystore configurations may now include an optional `ipAllowList` array. If
+  specified, the KMS system will only execute requests originating from IPs
+  listed in `ipAllowList`. This applies to key operations for all keys in the
+  keystore as well as modification of the configuration itself.
+
 ## 4.0.0 - 2021-03-02
 
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Bedrock Non-Commercial License v1.0
 ===================================
 
-Copyright (c) 2011-2020 Digital Bazaar, Inc.
+Copyright (c) 2011-2021 Digital Bazaar, Inc.
 All rights reserved.
 
 Summary

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,6 +10,7 @@ const {
   keystores,
   keyDescriptionStorage
 } = require('bedrock-kms');
+const forwarded = require('forwarded');
 const jsigs = require('jsonld-signatures');
 const {
   extendContextLoader,
@@ -19,6 +20,7 @@ const {
 const {config, util: {BedrockError}} = bedrock;
 const {verifyCapabilityInvocation} = require('http-signature-zcap-verify');
 const {CapabilityDelegation} = require('ocapld');
+const {Netmask} = require('netmask');
 
 // TODO: a lot of helper code here is in common w/ bedrock-data-hub-storage,
 // consider refactoring to share it
@@ -222,6 +224,30 @@ exports.verifyDelegation = async ({keystoreId, host, capability}) => {
     throw error;
   }
   return results;
+};
+
+exports.verifyRequestIp = ({keystoreConfig, req}) => {
+  const {ipAllowList} = keystoreConfig;
+  if(!ipAllowList) {
+    return {verified: true};
+  }
+
+  // the first IP in the sourceAddresses array will *always* be the IP
+  // reported by Express.js via `req.connection.remoteAddress`. Any additional
+  // IPs will be from the `x-forwarded-for` header.
+  const sourceAddresses = forwarded(req);
+
+  // ipAllowList is an array of CIDRs
+  for(const cidr of ipAllowList) {
+    const netmask = new Netmask(cidr);
+    for(const address of sourceAddresses) {
+      if(netmask.contains(address)) {
+        return {verified: true};
+      }
+    }
+  }
+
+  return {verified: false};
 };
 
 /**

--- a/lib/http-revocations.js
+++ b/lib/http-revocations.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/http-revocations.js
+++ b/lib/http-revocations.js
@@ -9,6 +9,7 @@ const brZCapStorage = require('bedrock-zcap-storage');
 const {config, util: {BedrockError}} = bedrock;
 const cors = require('cors');
 const helpers = require('./helpers');
+const {keystores} = require('bedrock-kms');
 const {validator: validate} = require('./validator');
 const {zcap: zcapSchema} = require('../schemas/bedrock-kms-http');
 
@@ -31,6 +32,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // check revocation
       const keystoreId = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
+
+      const {config: keystoreConfig} = await keystores.get({id: keystoreId});
+      const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
+      if(!verified) {
+        throw new BedrockError(
+          'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
+            httpStatusCode: 403,
+            public: true,
+          });
+      }
+
       const expectedTarget = `${keystoreId}/revocations`;
       const expectedRootCapability = `${keystoreId}/zcaps/revocations`;
       const {invoker} = await helpers.authorize({

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -391,13 +391,9 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   const result = await validateOperation({
     url, method, headers,
     operation,
-    // FIXME: this value is passed down to http-signature-zcap-verify
-    // where the `host` header is compared to the expected value:
-    // eslint-disable-next-line max-len
-    // https://github.com/digitalbazaar/http-signature-zcap-verify/blob/master/main.js#L82-L83
-    // if dispensing with `allowedHost`, does this simply become the local
-    // server config.server.host or domain?
-    expectedHost: config.kms.allowedHost,
+    // this value is passed down to http-signature-zcap-verify
+    // where the `host` header is compared to the expectedHost value
+    expectedHost: config.server.host,
     expectedRootCapability,
     getInvokedCapability: helpers.createGetInvokedCapability({host}),
     inspectCapabilityChain: helpers.inspectCapabilityChain,

--- a/lib/http.js
+++ b/lib/http.js
@@ -115,7 +115,13 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         {controller, query, fields: {_id: 0, config: 1}});
       // TODO: consider returning only IDs and let other endpoint handle
       // retrieval of full configs
-      res.json(results.map(r => r.config));
+
+      const filteredResult = results.filter(({config: keystoreConfig}) => {
+        const {verified} = _verifyRequestIp({keystoreConfig, req});
+        return verified;
+      });
+
+      res.json(filteredResult.map(r => r.config));
     }));
 
   // update keystore config
@@ -156,9 +162,18 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const id = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
 
-      const {config} = await keystores.get({id});
+      const {config: keystoreConfig} = await keystores.get({id});
 
-      res.json(config);
+      const {verified} = _verifyRequestIp({keystoreConfig, req});
+      if(!verified) {
+        throw new BedrockError(
+          'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
+            httpStatusCode: 403,
+            public: true,
+          });
+      }
+
+      res.json(keystoreConfig);
     }));
 
   // TODO: review before future implementation...

--- a/lib/http.js
+++ b/lib/http.js
@@ -19,6 +19,7 @@ const database = require('bedrock-mongodb');
 const URL = require('url').URL;
 const {generateRandom} = require('webkms-switch');
 const helpers = require('./helpers');
+const {Netmask} = require('netmask');
 const {validator: validate} = require('./validator');
 const {
   getKeystoreQuery,
@@ -212,7 +213,9 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     routes.key,
     cors(),
     asyncHandler(async (req, res) => {
-      const result = await _handleOperation({req});
+      const keystoreId = helpers.getKeystoreId(
+        {req, localId: req.params.keystoreId, routes});
+      const result = await _handleOperation({keystoreId, req});
       res.json(result);
     }));
 
@@ -398,15 +401,24 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
         public: true
       }, result.error);
   }
+
+  const {config: keystoreConfig} = await keystores.get({id: keystoreId});
+  const {verified} = _verifyRequestSource({keystoreConfig, req});
+  if(!verified) {
+    throw new BedrockError('Permission denied.', 'NotAllowedError', {
+      httpStatusCode: 403,
+      public: true,
+    });
+  }
+
   if(operation.type === 'GenerateKeyOperation') {
     // disallow generating a key with a controller that is different from the
     // keystore's controller
-    const {config} = await keystores.get({id: keystoreId});
     const {invocationTarget: {controller}} = operation;
-    if(controller !== undefined && controller !== config.controller) {
+    if(controller !== undefined && controller !== keystoreConfig.controller) {
       throw new BedrockError(
         `Invalid KMS operation; key controller (${controller}) must match ` +
-        `keystore controller (${config.controller}).`, 'DataError', {
+        `keystore controller (${keystoreConfig.controller}).`, 'DataError', {
           httpStatusCode: 400,
           public: true
         });
@@ -415,6 +427,29 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
     operation.invocationTarget.id = `${url}/${random}`;
   }
   return runOperation({operation});
+}
+
+function _verifyRequestSource({keystoreConfig, req}) {
+  const {ipAllowList} = keystoreConfig;
+  if(!ipAllowList) {
+    return {verified: true};
+  }
+
+  // TODO: get `Forwarded` header and possibly others to support operation
+  // behind a reverse proxy
+  const {socket: {remoteAddress}} = req;
+
+  let verified = false;
+  // ipAllowList is an array of CIDRs
+  for(const cidr of ipAllowList) {
+    const netmask = new Netmask(cidr);
+    if(netmask.contains(remoteAddress)) {
+      verified = true;
+      break;
+    }
+  }
+
+  return {verified};
 }
 
 function _verifyHost(url) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -375,7 +375,7 @@ async function getRootController({
 
 function _authorizeZcapInvocation({expectedTarget, expectedAction} = {}) {
   return authorizeZcapInvocation({
-    expectedHost: config.kms.allowedHost,
+    expectedHost: config.server.host,
     getRootController,
     documentLoader: _documentLoader,
     expectedTarget,

--- a/lib/http.js
+++ b/lib/http.js
@@ -392,6 +392,12 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   const result = await validateOperation({
     url, method, headers,
     operation,
+    // FIXME: this value is passed down to http-signature-zcap-verify
+    // where the `host` header is compared to the expected value:
+    // eslint-disable-next-line max-len
+    // https://github.com/digitalbazaar/http-signature-zcap-verify/blob/master/main.js#L82-L83
+    // if dispensing with `allowedHost`, does this simply become the local
+    // server config.server.host or domain?
     expectedHost: config.kms.allowedHost,
     expectedRootCapability,
     getInvokedCapability: helpers.createGetInvokedCapability({host}),

--- a/lib/http.js
+++ b/lib/http.js
@@ -16,7 +16,6 @@ const {createMiddleware} = require('bedrock-passport');
 const brZCapStorage = require('bedrock-zcap-storage');
 const cors = require('cors');
 const database = require('bedrock-mongodb');
-const URL = require('url').URL;
 const forwarded = require('forwarded');
 const {generateRandom} = require('webkms-switch');
 const helpers = require('./helpers');
@@ -84,7 +83,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       const random = await generateRandom();
       const id = helpers.getKeystoreId({req, localId: random, routes});
-      _verifyHost(id);
 
       // create a keystore for the controller
       const {config} = await keystores.insert({config: {id, ...req.body}});
@@ -128,7 +126,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     asyncHandler(async (req, res) => {
       const keystoreId = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
-      _verifyHost(keystoreId);
 
       const {config: keystoreConfig} = await keystores.get({id: keystoreId});
       const {verified} = _verifyRequestIp({keystoreConfig, req});
@@ -158,8 +155,9 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     asyncHandler(async (req, res) => {
       const id = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
-      _verifyHost(id);
+
       const {config} = await keystores.get({id});
+
       res.json(config);
     }));
 
@@ -183,7 +181,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // compute invocation target
       const host = req.get('host');
       const id = `https://${host}${req.originalUrl}`;
-      _verifyHost(id);
+
       const result = helpers.getInvocationTarget({host, url: id});
       if(!result) {
         // invalid root zcap ID
@@ -197,6 +195,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // dynamically generate root capability for target
       const zcap = await helpers.generateRootCapability(
         {id, target, keystoreId});
+
       res.json(zcap);
     }));
 
@@ -469,26 +468,6 @@ function _verifyRequestIp({keystoreConfig, req}) {
   }
 
   return {verified: false};
-}
-
-function _verifyHost(url) {
-
-  // FIXME: temporarily make verifyHost a noop
-  // !!! I believe we want to remove this host check entirely, is that correct?
-  return;
-
-  const {allowedHost} = config.kms;
-  const parsed = new URL(url);
-  const receivedHost = parsed.host;
-  if(receivedHost !== allowedHost) {
-    throw new BedrockError('Permission denied. Expected host ' +
-    `"${allowedHost}" but received "${receivedHost}".`, 'NotAllowedError', {
-      httpStatusCode: 400,
-      public: true,
-      allowedHost,
-      receivedHost
-    });
-  }
 }
 
 // Note: for dereferencing `did:` URLs

--- a/lib/http.js
+++ b/lib/http.js
@@ -17,6 +17,7 @@ const brZCapStorage = require('bedrock-zcap-storage');
 const cors = require('cors');
 const database = require('bedrock-mongodb');
 const URL = require('url').URL;
+const forwarded = require('forwarded');
 const {generateRandom} = require('webkms-switch');
 const helpers = require('./helpers');
 const {Netmask} = require('netmask');
@@ -435,17 +436,20 @@ function _verifyRequestSource({keystoreConfig, req}) {
     return {verified: true};
   }
 
-  // TODO: get `Forwarded` header and possibly others to support operation
-  // behind a reverse proxy
-  const {socket: {remoteAddress}} = req;
+  // the first IP in the sourceAddresses array will *always* be the IP
+  // reported by Express.js via `req.connection.remoteAddress`. Any additional
+  // IPs will be from the `x-forwarded-for` header.
+  const sourceAddresses = forwarded(req);
 
   let verified = false;
   // ipAllowList is an array of CIDRs
   for(const cidr of ipAllowList) {
     const netmask = new Netmask(cidr);
-    if(netmask.contains(remoteAddress)) {
-      verified = true;
-      break;
+    for(const address of sourceAddresses) {
+      if(netmask.contains(address)) {
+        verified = true;
+        break;
+      }
     }
   }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -126,9 +126,19 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     _authorizeZcapInvocation(),
     validate({bodySchema: updateKeystoreConfigBody}),
     asyncHandler(async (req, res) => {
-      const id = helpers.getKeystoreId(
+      const keystoreId = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
-      _verifyHost(id);
+      _verifyHost(keystoreId);
+
+      const {config: keystoreConfig} = await keystores.get({id: keystoreId});
+      const {verified} = _verifyRequestIp({keystoreConfig, req});
+      if(!verified) {
+        throw new BedrockError(
+          'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
+            httpStatusCode: 403,
+            public: true,
+          });
+      }
 
       // the `update` API will not apply the change if `config.sequence` is
       // not valid, no need to check it here
@@ -406,10 +416,11 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   const {config: keystoreConfig} = await keystores.get({id: keystoreId});
   const {verified} = _verifyRequestIp({keystoreConfig, req});
   if(!verified) {
-    throw new BedrockError('Permission denied.', 'NotAllowedError', {
-      httpStatusCode: 403,
-      public: true,
-    });
+    throw new BedrockError(
+      'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
+        httpStatusCode: 403,
+        public: true,
+      });
   }
 
   if(operation.type === 'GenerateKeyOperation') {

--- a/lib/http.js
+++ b/lib/http.js
@@ -474,7 +474,9 @@ function _verifyRequestIp({keystoreConfig, req}) {
 }
 
 function _verifyHost(url) {
-  // FIXME: temporarilily make verifyHost a noop
+
+  // FIXME: temporarily make verifyHost a noop
+  // !!! I believe we want to remove this host check entirely, is that correct?
   return;
 
   const {allowedHost} = config.kms;

--- a/lib/http.js
+++ b/lib/http.js
@@ -404,7 +404,7 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   }
 
   const {config: keystoreConfig} = await keystores.get({id: keystoreId});
-  const {verified} = _verifyRequestSource({keystoreConfig, req});
+  const {verified} = _verifyRequestIp({keystoreConfig, req});
   if(!verified) {
     throw new BedrockError('Permission denied.', 'NotAllowedError', {
       httpStatusCode: 403,
@@ -430,7 +430,7 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   return runOperation({operation});
 }
 
-function _verifyRequestSource({keystoreConfig, req}) {
+function _verifyRequestIp({keystoreConfig, req}) {
   const {ipAllowList} = keystoreConfig;
   if(!ipAllowList) {
     return {verified: true};

--- a/lib/http.js
+++ b/lib/http.js
@@ -16,10 +16,8 @@ const {createMiddleware} = require('bedrock-passport');
 const brZCapStorage = require('bedrock-zcap-storage');
 const cors = require('cors');
 const database = require('bedrock-mongodb');
-const forwarded = require('forwarded');
 const {generateRandom} = require('webkms-switch');
 const helpers = require('./helpers');
-const {Netmask} = require('netmask');
 const {validator: validate} = require('./validator');
 const {
   getKeystoreQuery,
@@ -117,7 +115,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // retrieval of full configs
 
       const filteredResult = results.filter(({config: keystoreConfig}) => {
-        const {verified} = _verifyRequestIp({keystoreConfig, req});
+        const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
         return verified;
       });
 
@@ -134,7 +132,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         {req, localId: req.params.keystoreId, routes});
 
       const {config: keystoreConfig} = await keystores.get({id: keystoreId});
-      const {verified} = _verifyRequestIp({keystoreConfig, req});
+      const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
       if(!verified) {
         throw new BedrockError(
           'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
@@ -164,7 +162,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       const {config: keystoreConfig} = await keystores.get({id});
 
-      const {verified} = _verifyRequestIp({keystoreConfig, req});
+      const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
       if(!verified) {
         throw new BedrockError(
           'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
@@ -430,7 +428,7 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
   }
 
   const {config: keystoreConfig} = await keystores.get({id: keystoreId});
-  const {verified} = _verifyRequestIp({keystoreConfig, req});
+  const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
   if(!verified) {
     throw new BedrockError(
       'Permission denied. Source IP is not allowed.', 'NotAllowedError', {
@@ -455,30 +453,6 @@ async function _handleOperation({req, expectedRootCapability, keystoreId}) {
     operation.invocationTarget.id = `${url}/${random}`;
   }
   return runOperation({operation});
-}
-
-function _verifyRequestIp({keystoreConfig, req}) {
-  const {ipAllowList} = keystoreConfig;
-  if(!ipAllowList) {
-    return {verified: true};
-  }
-
-  // the first IP in the sourceAddresses array will *always* be the IP
-  // reported by Express.js via `req.connection.remoteAddress`. Any additional
-  // IPs will be from the `x-forwarded-for` header.
-  const sourceAddresses = forwarded(req);
-
-  // ipAllowList is an array of CIDRs
-  for(const cidr of ipAllowList) {
-    const netmask = new Netmask(cidr);
-    for(const address of sourceAddresses) {
-      if(netmask.contains(address)) {
-        return {verified: true};
-      }
-    }
-  }
-
-  return {verified: false};
 }
 
 // Note: for dereferencing `did:` URLs

--- a/lib/http.js
+++ b/lib/http.js
@@ -468,6 +468,9 @@ function _verifyRequestIp({keystoreConfig, req}) {
 }
 
 function _verifyHost(url) {
+  // FIXME: temporarilily make verifyHost a noop
+  return;
+
   const {allowedHost} = config.kms;
   const parsed = new URL(url);
   const receivedHost = parsed.host;

--- a/lib/http.js
+++ b/lib/http.js
@@ -128,8 +128,19 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     _authorizeZcapInvocation(),
     validate({bodySchema: updateKeystoreConfigBody}),
     asyncHandler(async (req, res) => {
+      const {body: config} = req;
       const keystoreId = helpers.getKeystoreId(
         {req, localId: req.params.keystoreId, routes});
+      if(keystoreId !== req.body.id) {
+        throw new BedrockError(
+          'Configuration "id" does not match.',
+          'DataError', {
+            httpStatusCode: 400,
+            public: true,
+            expected: keystoreId,
+            actual: config.id
+          });
+      }
 
       const {config: keystoreConfig} = await keystores.get({id: keystoreId});
       const {verified} = helpers.verifyRequestIp({keystoreConfig, req});
@@ -143,7 +154,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       // the `update` API will not apply the change if `config.sequence` is
       // not valid, no need to check it here
-      const {body: config} = req;
       await keystores.update({config});
 
       res.json({success: true, config});
@@ -382,7 +392,6 @@ async function getRootController({
     }
     throw e;
   }
-
   return controller;
 }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -458,19 +458,17 @@ function _verifyRequestIp({keystoreConfig, req}) {
   // IPs will be from the `x-forwarded-for` header.
   const sourceAddresses = forwarded(req);
 
-  let verified = false;
   // ipAllowList is an array of CIDRs
   for(const cidr of ipAllowList) {
     const netmask = new Netmask(cidr);
     for(const address of sourceAddresses) {
       if(netmask.contains(address)) {
-        verified = true;
-        break;
+        return {verified: true};
       }
     }
   }
 
-  return {verified};
+  return {verified: false};
 }
 
 function _verifyHost(url) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonld-signatures": "^7.0.0",
     "netmask": "^1.0.6",
     "ocapld": "^2.0.0",
-    "webkms-switch": "digitalbazaar/webkms-switch#next-release-zcap"
+    "webkms-switch": "^3.0.0"
   },
   "peerDependencies": {
     "bedrock": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonld-signatures": "^5.1.0",
     "netmask": "^1.0.6",
     "ocapld": "^2.0.0",
-    "webkms-switch": "^2.0.0"
+    "webkms-switch": "digitalbazaar/webkms-switch#next-release-zcap"
   },
   "peerDependencies": {
     "bedrock": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "did-veres-one": "^12.1.1",
     "http-signature-zcap-verify": "^3.0.0",
     "jsonld-signatures": "^5.1.0",
+    "netmask": "^1.0.6",
     "ocapld": "^2.0.0",
     "webkms-switch": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "did-method-key": "^0.7.0",
     "did-veres-one": "^12.1.1",
     "forwarded": "^0.1.2",
-    "http-signature-zcap-verify": "^3.0.0",
+    "http-signature-zcap-verify": "^4.0.0",
     "jsonld-signatures": "^5.1.0",
     "netmask": "^1.0.6",
     "ocapld": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bedrock-account": "3.x - 5.x",
     "bedrock-express": "^3.2.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-kms": "^4.0.0",
+    "bedrock-kms": "^5.0.0",
     "bedrock-mongodb": "^8.2.0",
     "bedrock-passport": "^6.0.0",
     "bedrock-permission": "2.x - 3.x",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-kms-http",
   "dependencies": {
     "@digitalbazaar/ezcap-express": "^1.0.0",
+    "cidr-regex": "^3.1.1",
     "cors": "^2.8.5",
     "did-io": "^0.8.3",
     "did-method-key": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bedrock-account": "3.x - 5.x",
     "bedrock-express": "^3.2.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-kms": "2.x - 3.x",
+    "bedrock-kms": "^4.0.0",
     "bedrock-mongodb": "^8.2.0",
     "bedrock-passport": "^6.0.0",
     "bedrock-permission": "2.x - 3.x",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "did-io": "^0.8.3",
     "did-method-key": "^0.7.0",
     "did-veres-one": "^12.1.1",
+    "forwarded": "^0.1.2",
     "http-signature-zcap-verify": "^3.0.0",
     "jsonld-signatures": "^5.1.0",
     "netmask": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "did-veres-one": "^12.1.1",
     "forwarded": "^0.1.2",
     "http-signature-zcap-verify": "^4.0.0",
-    "jsonld-signatures": "^5.1.0",
+    "jsonld-signatures": "^7.0.0",
     "netmask": "^1.0.6",
     "ocapld": "^2.0.0",
     "webkms-switch": "digitalbazaar/webkms-switch#next-release-zcap"

--- a/schemas/bedrock-kms-http.js
+++ b/schemas/bedrock-kms-http.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/schemas/bedrock-kms-http.js
+++ b/schemas/bedrock-kms-http.js
@@ -40,7 +40,8 @@ const ipAllowList = {
   minItems: 1,
   items: {
     type: 'string',
-    pattern: cidrRegex.v4({exact: true}).toString(),
+    // leading and trailing slashes in regex must be removed
+    pattern: cidrRegex.v4({exact: true}).toString().slice(1, -1),
   }
 };
 

--- a/schemas/bedrock-kms-http.js
+++ b/schemas/bedrock-kms-http.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const cidrRegex = require('cidr-regex');
+
 const controller = {
   title: 'controller',
   type: 'string'
@@ -33,6 +35,15 @@ const invoker = {
   }]
 };
 
+const ipAllowList = {
+  type: 'array',
+  minItems: 1,
+  items: {
+    type: 'string',
+    pattern: cidrRegex.v4({exact: true}).toString(),
+  }
+};
+
 const sequence = {
   title: 'sequence',
   type: 'integer',
@@ -47,6 +58,7 @@ const postKeystoreBody = {
   required: ['sequence', 'controller'],
   properties: {
     controller,
+    ipAllowList,
     referenceId,
     sequence,
   }
@@ -185,6 +197,7 @@ const updateKeystoreConfigBody = {
   properties: {
     controller,
     id: {type: 'string'},
+    ipAllowList,
     referenceId,
     sequence,
   }

--- a/test/mocha/10-keystore.js
+++ b/test/mocha/10-keystore.js
@@ -286,28 +286,6 @@ describe('bedrock-kms-http API', () => {
           'A validation error occured in the \'postRecoverBody\' validator.');
       });
 
-    // FIXME: is allowedHost going to continue on?
-    // eslint-disable-next-line max-len
-    it.skip('throws error on receivedHost not equal to allowedHost', async () => {
-      const secret = ' b07e6b31-d910-438e-9a5f-08d945a5f676';
-      const handle = 'testKey1';
-      const capabilityAgent = await CapabilityAgent
-        .fromSecret({secret, handle});
-      let err;
-      let result;
-
-      // intentionally specifying a host name other than a local host
-      const kmsBaseUrl = 'https://127.0.0.1:18443/kms';
-
-      try {
-        result = await helpers.createKeystore({capabilityAgent, kmsBaseUrl});
-      } catch(e) {
-        err = e;
-      }
-      should.not.exist(result);
-      should.exist(err);
-      err.data.message.should.contain('Permission denied. Expected host');
-    });
     describe('update keystore config', () => {
       it('updates a keystore config', async () => {
         const secret = '69ae7dc3-1d6d-4ff9-9cc0-c07b43d2006b';

--- a/test/mocha/10-keystore.js
+++ b/test/mocha/10-keystore.js
@@ -285,7 +285,10 @@ describe('bedrock-kms-http API', () => {
         err.data.message.should.equal(
           'A validation error occured in the \'postRecoverBody\' validator.');
       });
-    it('throws error on receivedHost not equal to allowedHost', async () => {
+
+    // FIXME: is allowedHost going to continue on?
+    // eslint-disable-next-line max-len
+    it.skip('throws error on receivedHost not equal to allowedHost', async () => {
       const secret = ' b07e6b31-d910-438e-9a5f-08d945a5f676';
       const handle = 'testKey1';
       const capabilityAgent = await CapabilityAgent

--- a/test/mocha/10-keystore.js
+++ b/test/mocha/10-keystore.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/10-keystore.js
+++ b/test/mocha/10-keystore.js
@@ -65,7 +65,7 @@ describe('bedrock-kms-http API', () => {
       const capabilityAgent = await CapabilityAgent
         .fromSecret({secret, handle});
 
-      // this is no a valid CIDR
+      // this is not a valid CIDR
       const ipAllowList = ['127.0.0.1/33'];
 
       let err;

--- a/test/mocha/11-keystore-kms-client.js
+++ b/test/mocha/11-keystore-kms-client.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const brHttpsAgent = require('bedrock-https-agent');
+const helpers = require('./helpers');
+const {CapabilityAgent, KmsClient, KeystoreAgent} = require('webkms-client');
+
+describe('keystore API interactions using webkms-client', () => {
+  let aliceCapabilityAgent;
+  let aliceKeystoreConfig;
+  let aliceKeystoreAgent;
+  let bobCapabilityAgent;
+  let bobKeystoreAgent;
+
+  before(async () => {
+    const secret = '40762a17-1696-428f-a2b2-ddf9fe9b4987';
+    const handle = 'testKey2';
+    aliceCapabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
+
+    aliceKeystoreConfig = await helpers.createKeystore(
+      {capabilityAgent: aliceCapabilityAgent});
+    const {httpsAgent} = brHttpsAgent;
+    const kmsClient = new KmsClient({httpsAgent});
+
+    // eslint-disable-next-line no-unused-vars
+    aliceKeystoreAgent = new KeystoreAgent({
+      capabilityAgent: aliceCapabilityAgent,
+      keystore: aliceKeystoreConfig,
+      kmsClient,
+    });
+  });
+
+  // generate a keystore for Bob
+  before(async () => {
+    const secret = '34f2afd1-34ef-4d46-a998-cdc5462dc0d2';
+    const handle = 'bobKey';
+    bobCapabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
+    const keystore = await helpers.createKeystore(
+      {capabilityAgent: bobCapabilityAgent});
+    try {
+      const {httpsAgent} = brHttpsAgent;
+      const kmsClient = new KmsClient({httpsAgent});
+      bobKeystoreAgent = new KeystoreAgent(
+        {capabilityAgent: bobCapabilityAgent, keystore, kmsClient});
+    } catch(e) {
+      assertNoError(e);
+    }
+  });
+
+  it('returns DataError on attempt to update and invalid config', async () => {
+    // update Alice's keystore config to include ipAllowList
+    aliceKeystoreConfig.sequence++;
+    aliceKeystoreConfig.ipAllowList = ['8.8.8.8/32'];
+
+    let err;
+    let result;
+    try {
+      result = await bobKeystoreAgent.updateConfig(
+        {config: aliceKeystoreConfig});
+    } catch(e) {
+      err = e;
+    }
+    should.not.exist(result);
+    should.exist(err);
+    err.status.should.equal(400);
+    err.data.message.should.equal('Configuration "id" does not match.');
+    err.data.type.should.equal('DataError');
+    err.data.details.should.have.keys('httpStatusCode', 'expected', 'actual');
+    err.data.details.actual.should.equal(aliceKeystoreConfig.id);
+    err.data.details.expected.should.equal(bobKeystoreAgent.keystore.id);
+  });
+});

--- a/test/mocha/20-revocation.js
+++ b/test/mocha/20-revocation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/21-revocation-ip-allow-list.js
+++ b/test/mocha/21-revocation-ip-allow-list.js
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const bedrock = require('bedrock');
+const brHttpsAgent = require('bedrock-https-agent');
+const {documentLoader} = require('bedrock-jsonld-document-loader');
+const helpers = require('./helpers');
+const jsigs = require('jsonld-signatures');
+const {CapabilityDelegation} = require('ocapld');
+const {AsymmetricKey, CapabilityAgent, KmsClient, KeystoreAgent} =
+  require('webkms-client');
+const {Ed25519KeyPair} = require('crypto-ld');
+const {util: {uuid}} = bedrock;
+const {
+  purposes: {AssertionProofPurpose},
+  sign,
+  suites: {Ed25519Signature2018}
+} = jsigs;
+
+const KMS_MODULE = 'ssm-v1';
+
+describe('revocations API with ipAllowList', () => {
+  let aliceCapabilityAgent;
+  let aliceKeystoreConfig;
+  let aliceKeystoreAgent;
+  let bobCapabilityAgent;
+  let bobKeystoreAgent;
+  let bobKey;
+  let carolCapabilityAgent;
+  let carolKey;
+  let carolKeystoreAgent;
+
+  before(async () => {
+    const secret = '40762a17-1696-428f-a2b2-ddf9fe9b4987';
+    const handle = 'testKey2';
+    aliceCapabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
+
+    aliceKeystoreConfig = await helpers.createKeystore(
+      {capabilityAgent: aliceCapabilityAgent});
+    const {httpsAgent} = brHttpsAgent;
+    const kmsClient = new KmsClient({httpsAgent});
+    aliceKeystoreAgent = new KeystoreAgent({
+      capabilityAgent: aliceCapabilityAgent,
+      keystore: aliceKeystoreConfig,
+      kmsClient,
+    });
+  });
+
+  // generate a keystore for Bob
+  before(async () => {
+    const secret = '34f2afd1-34ef-4d46-a998-cdc5462dc0d2';
+    const handle = 'bobKey';
+    bobCapabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
+    const keystore = await helpers.createKeystore(
+      {capabilityAgent: bobCapabilityAgent});
+    try {
+      const {httpsAgent} = brHttpsAgent;
+      const kmsClient = new KmsClient({httpsAgent});
+      bobKeystoreAgent = new KeystoreAgent(
+        {capabilityAgent: bobCapabilityAgent, keystore, kmsClient});
+    } catch(e) {
+      assertNoError(e);
+    }
+    try {
+      bobKey = await bobKeystoreAgent.generateKey(
+        {type: 'Ed25519VerificationKey2018', kmsModule: KMS_MODULE});
+    } catch(e) {
+      assertNoError(e);
+    }
+    await _setKeyId(bobKey);
+  });
+
+  // generate a keystore for Carol
+  before(async () => {
+    const secret = 'ae806cd9-2765-4232-b955-01e1024ac032';
+    const handle = 'carolKey';
+    const {httpsAgent} = brHttpsAgent;
+    // keystore in the kmsClient is set later
+    const kmsClient = new KmsClient({httpsAgent});
+    carolCapabilityAgent = await CapabilityAgent.fromSecret({
+      secret, handle, kmsClient
+    });
+    const keystore = await helpers.createKeystore(
+      {capabilityAgent: carolCapabilityAgent});
+    carolKeystoreAgent = new KeystoreAgent(
+      {capabilityAgent: carolCapabilityAgent, keystore, kmsClient});
+
+    carolKey = await carolKeystoreAgent.generateKey(
+      {type: 'Ed25519VerificationKey2018', kmsModule: KMS_MODULE});
+    await _setKeyId(carolKey);
+  });
+
+  // mock session authentication for delegations endpoint
+  let passportStub;
+  before(() => {
+    const actor = {
+      id: 'urn:uuid:7d1f8aea-5a22-480e-840b-d60bc5705864'
+    };
+    passportStub = helpers.stubPassport({actor});
+  });
+  after(() => {
+    passportStub.restore();
+  });
+
+  it('returns NotAllowedError for invalid source IP', async () => {
+    // first generate a new key for alice
+    const aliceKey = await aliceKeystoreAgent.generateKey(
+      {type: 'Ed25519VerificationKey2018', kmsModule: KMS_MODULE});
+    await _setKeyId(aliceKey);
+
+    // next, delegate authority to bob to use alice's key
+    const zcap = {
+      '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
+      // this is a unique ID
+      id: `urn:zcap:${uuid()}`,
+      // this is Bob's capabilityInvocation key that will be used to invoke
+      // the capability
+      invoker: bobKey.id,
+      // this provides Bob the ability to delegate the capability again to
+      // Carol later
+      delegator: bobKey.id,
+      // if parentCapability points to a root capability it must be a
+      // URL that can be dereferenced. In this case, aliceKey.kmsId is a root
+      // capability.
+      parentCapability: aliceKey.kmsId,
+      allowedAction: 'sign',
+      invocationTarget: {
+        verificationMethod: aliceKey.id,
+        id: aliceKey.kmsId,
+        type: aliceKey.type,
+      }
+    };
+
+    // This capability allows Bob to write to this revocations endpoint
+    // This capability is required for Bob to revoke Carol's capability later.
+
+    // the invoker for writing must be the delegator of the capability that is
+    // being revoked there should also be a check that the invocation target
+    // exists on the host system
+    const bobRevocationZcap = {
+      '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
+      // this is a unique ID
+      id: `urn:zcap:${uuid()}`,
+      invoker: bobKey.id,
+      // there is no root capability at the `invocationTarget` location,
+      // so this alternate URL is used that will automatically generate a
+      // root capability
+      parentCapability: `${aliceKeystoreAgent.keystore.id}/zcaps/revocations`,
+      allowedAction: 'write',
+      invocationTarget: `${aliceKeystoreAgent.keystore.id}/revocations`,
+    };
+
+    // Alice now signs the capability delegation that allows Bob to `sign`
+    // with her key.
+    const signer = aliceCapabilityAgent.getSigner();
+    const signedCapabilityFromAlice = await _delegate({
+      capabilityChain: [
+        // Alice's key is the root capability which is always the first
+        // item in the `capabilityChain`
+        aliceKey.kmsId
+      ],
+      signer,
+      zcap
+    });
+
+    // Alice now signs the capability delegation that allows Bob to `write`
+    // to Alice's keystore revocations endpoint
+    const signedBobRevocationZcap = await _delegate({
+      capabilityChain: [bobRevocationZcap.parentCapability],
+      signer,
+      zcap: bobRevocationZcap
+    });
+
+    // Bob now uses his delegated authority to sign a document with Alice's key
+    const bobSignedDocument = await _signWithDelegatedKey({
+      capability: signedCapabilityFromAlice,
+      invokeKey: bobKey,
+    });
+
+    bobSignedDocument.should.have.property('@context');
+    bobSignedDocument.should.have.property('nonce');
+    bobSignedDocument.should.have.property('proof');
+    bobSignedDocument.proof.should.have.property('verificationMethod');
+    // the document was ultimately signed with alice's key
+    bobSignedDocument.proof.verificationMethod.should.equal(aliceKey.id);
+
+    // Bob has successfully used alice's key to sign a document!
+
+    // Bob now delegates the use of Alice's key to Carol
+    const carolZcap = {
+      '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
+      // this is a unique ID
+      id: `urn:zcap:${uuid()}`,
+      invoker: carolKey.id,
+      // the capability Alice gave to Bob
+      parentCapability: zcap.id,
+      // this is where we need to ensure the allowedAction here is included
+      // in the allowedAction of the parentCapability, there is an issue in
+      // ocapld for this.
+      allowedAction: 'sign',
+      invocationTarget: zcap.invocationTarget,
+    };
+
+    // finish bobs delegation to carol
+    const signedCapabilityFromBobToCarol = await _delegate({
+      capabilityChain: [
+        aliceKey.kmsId,
+        zcap,
+      ],
+      signer: bobKey,
+      zcap: carolZcap
+    });
+
+    // Bob would then store record of the delegation to Carol in an EDV
+
+    // demonstrate that Carol can also sign with Alice's key
+    const carolSignedDocument = await _signWithDelegatedKey({
+      capability: signedCapabilityFromBobToCarol,
+      invokeKey: carolKey,
+    });
+    carolSignedDocument.should.have.property('@context');
+    carolSignedDocument.should.have.property('nonce');
+    carolSignedDocument.should.have.property('proof');
+    carolSignedDocument.proof.should.have.property('verificationMethod');
+    // the document was ultimately signed with alice's key
+    carolSignedDocument.proof.verificationMethod.should.equal(aliceKey.id);
+
+    // update Alice's keystore config to include ipAllowList
+    aliceKeystoreConfig.sequence++;
+    aliceKeystoreConfig.ipAllowList = ['8.8.8.8/32'];
+
+    const {success} = await aliceKeystoreAgent.updateConfig(
+      {config: aliceKeystoreConfig});
+    success.should.equal(true);
+
+    // Bob now submits a revocation using his revocation capability to
+    // revoke the capability he gave to Carol.
+
+    // in practice bob is going to locate the capability he gave to carol
+    // by way of bedrock-web-zcap-storage
+
+    // this adds a revocation for Carol's `sign` capability on Alice's
+    // kms system
+
+    // this request should fails because the request does not originate from
+    // an IP in the `ipAllowList` on Alice's keystore.
+    let err;
+    let result;
+    try {
+      result = await _revokeDelegatedCapability({
+        // the capability here is to `write` to a revocations endpoint on
+        // Alice's system
+        capability: signedBobRevocationZcap,
+        // the `sign` capability that Bob gave to Carol
+        capabilityToRevoke: signedCapabilityFromBobToCarol,
+        // bobKey is the `invoker` in `signedBobRevocationZcap`
+        invocationSigner: bobKey
+      });
+    } catch(e) {
+      err = e;
+    }
+    should.not.exist(result);
+    should.exist(err);
+    err.status.should.equal(403);
+    err.data.message.should.contain('Source IP');
+    err.data.type.should.equal('NotAllowedError');
+  });
+});
+
+async function _delegate({zcap, signer, capabilityChain}) {
+  // attach capability delegation proof
+  return sign(zcap, {
+    // TODO: map `signer.type` to signature suite
+    suite: new Ed25519Signature2018({
+      signer,
+      verificationMethod: signer.id
+    }),
+    purpose: new CapabilityDelegation({capabilityChain}),
+    compactProof: false
+  });
+}
+
+async function _signWithDelegatedKey({capability, doc, invokeKey}) {
+  const {httpsAgent} = brHttpsAgent;
+  const delegatedSigningKey = new AsymmetricKey({
+    capability,
+    invocationSigner: invokeKey,
+    kmsClient: new KmsClient({httpsAgent})
+  });
+  const suite = new Ed25519Signature2018({
+    verificationMethod: capability.invocationTarget.verificationMethod,
+    signer: delegatedSigningKey
+  });
+
+  doc = doc || {
+    '@context': bedrock.config.constants.SECURITY_CONTEXT_V2_URL,
+    // just using a term out of security context
+    nonce: 'bar'
+  };
+
+  return sign(doc, {
+    documentLoader,
+    suite,
+    purpose: new AssertionProofPurpose(),
+  });
+}
+
+async function _revokeDelegatedCapability({
+  capability, capabilityToRevoke, invocationSigner
+}) {
+  const {httpsAgent} = brHttpsAgent;
+  const kmsClient = new KmsClient({httpsAgent});
+  await kmsClient.revokeCapability({
+    capabilityToRevoke,
+    capability,
+    invocationSigner
+  });
+}
+
+async function _setKeyId(key) {
+  // the keyDescription is required to get publicKeyBase58
+  const keyDescription = await key.getKeyDescription();
+  // create public ID (did:key) for bob's key
+  // TODO: do not use did:key but support a did:v1 based key.
+  const fingerprint = Ed25519KeyPair.fingerprintFromPublicKey(keyDescription);
+  // invocationTarget.verificationMethod = `did:key:${fingerprint}`;
+  key.id = `did:key:${fingerprint}#${fingerprint}`;
+}

--- a/test/mocha/30-operations-generate-key.js
+++ b/test/mocha/30-operations-generate-key.js
@@ -32,6 +32,33 @@ describe('generateKey with ipAllowList', () => {
       'cache', '_pruneCacheTimer'
     ]);
   });
+  it('generates a key with x-forwarded-for header', async () => {
+    // source of requests in the test suite are from 127.0.0.1
+    const secret = ' 22612679-05ce-4ffd-bf58-22b3c4bc1314';
+    const handle = 'testKeyAllowList';
+    const ipAllowList = ['8.8.8.8/32'];
+    const keystoreAgent = await helpers.createKeystoreAgent({
+      handle, ipAllowList, secret, kmsClientHeaders: {
+        'x-forwarded-for': '8.8.8.8',
+      },
+    });
+    let err;
+    let result;
+    try {
+      result = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+    } catch(e) {
+      err = e;
+    }
+    assertNoError(err);
+    should.exist(result);
+    result.should.have.keys([
+      'algorithm', 'capability', 'id', 'type', 'invocationSigner', 'kmsClient',
+      'cache', '_pruneCacheTimer'
+    ]);
+  });
   it('generates a key with multiple ipAllowList entries', async () => {
     // source of requests in the test suite are from 127.0.0.1
     const secret = ' efef2772-f7aa-4d25-9eac-6228f2a64b3b';

--- a/test/mocha/30-operations-generate-key.js
+++ b/test/mocha/30-operations-generate-key.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const helpers = require('./helpers');
+
+const KMS_MODULE = 'ssm-v1';
+
+describe('generateKey with ipAllowList', () => {
+  it('generates a key', async () => {
+    // source of requests in the test suite are from 127.0.0.1
+    const secret = ' 22612679-05ce-4ffd-bf58-22b3c4bc1314';
+    const handle = 'testKeyAllowList';
+    const ipAllowList = ['127.0.0.1/32'];
+    const keystoreAgent = await helpers.createKeystoreAgent(
+      {handle, ipAllowList, secret});
+    let err;
+    let result;
+    try {
+      result = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+    } catch(e) {
+      err = e;
+    }
+    assertNoError(err);
+    should.exist(result);
+    result.should.have.keys([
+      'algorithm', 'capability', 'id', 'type', 'invocationSigner', 'kmsClient',
+      'cache', '_pruneCacheTimer'
+    ]);
+  });
+  it('generates a key with multiple ipAllowList entries', async () => {
+    // source of requests in the test suite are from 127.0.0.1
+    const secret = ' efef2772-f7aa-4d25-9eac-6228f2a64b3b';
+    const handle = 'testKeyAllowList';
+    const ipAllowList = ['8.8.8.8/32', '127.0.0.1/32'];
+    const keystoreAgent = await helpers.createKeystoreAgent(
+      {handle, ipAllowList, secret});
+    let err;
+    let result;
+    try {
+      result = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+    } catch(e) {
+      err = e;
+    }
+    assertNoError(err);
+    should.exist(result);
+    result.should.have.keys([
+      'algorithm', 'capability', 'id', 'type', 'invocationSigner', 'kmsClient',
+      'cache', '_pruneCacheTimer'
+    ]);
+  });
+  it('returns NotAllowedError for invalid source IP', async () => {
+    // source of requests in the test suite are from 127.0.0.1
+    const secret = '860a6bc8-74e1-4dfd-b701-7efc2a596e91';
+    const handle = 'testKeyAllowList';
+    const ipAllowList = ['8.8.8.8/32'];
+    const keystoreAgent = await helpers.createKeystoreAgent(
+      {handle, ipAllowList, secret});
+
+    let err;
+    let result;
+    try {
+      result = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+    } catch(e) {
+      err = e;
+    }
+    should.exist(err);
+    should.not.exist(result);
+    err.status.should.equal(403);
+    err.data.type.should.equal('NotAllowedError');
+  });
+}); // generateKey with ipAllowList

--- a/test/mocha/30-operations-generate-key.js
+++ b/test/mocha/30-operations-generate-key.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/31-operations-hmac.js
+++ b/test/mocha/31-operations-hmac.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/31-operations-hmac.js
+++ b/test/mocha/31-operations-hmac.js
@@ -35,35 +35,6 @@ describe('bedrock-kms-http HMAC operations', () => {
       should.exist(result);
       result.should.be.a('string');
     });
-
-    describe('bulk operations', () => {
-      const operationCount = 10000;
-      const vData = [];
-      before(async () => {
-        for(let i = 0; i < operationCount; ++i) {
-          let v = '';
-          for(let n = 0; n < 100; ++n) {
-            v += uuid();
-          }
-          vData.push(new TextEncoder('utf-8').encode(v));
-        }
-      });
-      it(`performs ${operationCount} signatures`, async function() {
-        this.timeout(0);
-        let result;
-        let err;
-        try {
-          result = await pMap(
-            vData, data => hmac.sign({data}), {concurrency: 10});
-        } catch(e) {
-          err = e;
-        }
-        assertNoError(err);
-        should.exist(result);
-        result.should.be.an('array');
-        result.should.have.length(operationCount);
-      });
-    }); // end bulk operations
   }); // end Sha256HmacKey2019
 
   describe('Sha256HmacKey2019 with ipAllowList', () => {
@@ -89,5 +60,70 @@ describe('bedrock-kms-http HMAC operations', () => {
       should.exist(result);
       result.should.be.a('string');
     });
+    it('successfully signs with x-forwarded-for header', async () => {
+      const secret = ' 2726f62d-31bb-4688-b54a-1a0b4e50329f';
+      const handle = 'testKeyAllowList';
+      const ipAllowList = ['8.8.8.8/32'];
+      const keystoreAgent = await helpers.createKeystoreAgent({
+        handle, ipAllowList, secret, kmsClientHeaders: {
+          'x-forwarded-for': '8.8.8.8',
+        },
+      });
+      const hmac = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+      const data = new TextEncoder('utf-8').encode('hello');
+      let err;
+      let result;
+      try {
+        result = await hmac.sign({data});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.a('string');
+    });
   }); // end Sha256HmacKey2019 with ipAllowList
+
+  describe('bulk operations', () => {
+    const operationCount = 10000;
+    const vData = [];
+    let hmac;
+
+    before(async () => {
+      const secret = ' 9b5a0a63-aac2-447c-a60a-8cc79b46418d';
+      const handle = 'testKeyBulk';
+      const keystoreAgent = await helpers.createKeystoreAgent({handle, secret});
+      hmac = await keystoreAgent.generateKey({
+        kmsModule: KMS_MODULE,
+        type: 'hmac',
+      });
+    });
+    before(async () => {
+      for(let i = 0; i < operationCount; ++i) {
+        let v = '';
+        for(let n = 0; n < 100; ++n) {
+          v += uuid();
+        }
+        vData.push(new TextEncoder('utf-8').encode(v));
+      }
+    });
+    it(`performs ${operationCount} signatures`, async function() {
+      this.timeout(0);
+      let result;
+      let err;
+      try {
+        result = await pMap(
+          vData, data => hmac.sign({data}), {concurrency: 10});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.be.an('array');
+      result.should.have.length(operationCount);
+    });
+  }); // end bulk operations
 });

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const bedrock = require('bedrock');
-const brHttpsAgent = require('bedrock-https-agent');
+const {httpsAgent} = require('bedrock-https-agent');
 const {KmsClient} = require('webkms-client');
 const brPassport = require('bedrock-passport');
 const sinon = require('sinon');
@@ -12,8 +12,8 @@ const sinon = require('sinon');
 // the `keystores` endpoint uses session based authentication which is
 // mocked
 exports.createKeystore = async ({
-  capabilityAgent, referenceId,
-  kmsBaseUrl = `${bedrock.config.server.baseUri}/kms`
+  capabilityAgent, ipAllowList, referenceId,
+  kmsBaseUrl = `${bedrock.config.server.baseUri}/kms`,
 }) => {
   // create keystore
   const config = {
@@ -23,8 +23,10 @@ exports.createKeystore = async ({
   if(referenceId) {
     config.referenceId = referenceId;
   }
+  if(ipAllowList) {
+    config.ipAllowList = ipAllowList;
+  }
 
-  const {httpsAgent} = brHttpsAgent;
   return KmsClient.createKeystore({
     url: `${kmsBaseUrl}/keystores`,
     config,
@@ -33,7 +35,6 @@ exports.createKeystore = async ({
 };
 
 exports.getKeystore = async ({id}) => {
-  const {httpsAgent} = brHttpsAgent;
   return KmsClient.getKeystore({id, httpsAgent});
 };
 
@@ -43,7 +44,6 @@ exports.findKeystore = async ({
 }) => {
   const url = `${kmsBaseUrl}/keystores` +
     `/?controller=${controller}&referenceId=${referenceId}`;
-  const {httpsAgent} = brHttpsAgent;
   return KmsClient.findKeystore({
     url, controller, referenceId, httpsAgent
   });

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -34,7 +34,9 @@ exports.createKeystore = async ({
   });
 };
 
-exports.createKeystoreAgent = async ({handle, ipAllowList, secret}) => {
+exports.createKeystoreAgent = async ({
+  handle, ipAllowList, secret, kmsClientHeaders = {}
+}) => {
   const capabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
 
   let err;
@@ -48,7 +50,8 @@ exports.createKeystoreAgent = async ({handle, ipAllowList, secret}) => {
 
   // create kmsClient only required because we need to use httpsAgent
   // that accepts self-signed certs used in test suite
-  const kmsClient = new KmsClient({httpsAgent});
+  const kmsClient = new KmsClient(
+    {httpsAgent, defaultHeaders: kmsClientHeaders});
   const keystoreAgent = new KeystoreAgent({
     capabilityAgent,
     keystore,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 
 /* eslint-disable max-len */

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-karma": "^2.1.0",
-    "bedrock-kms": "^3.0.1",
+    "bedrock-kms": "digitalbazaar/bedrock-kms#keystore-config-update",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-karma": "^2.1.0",
-    "bedrock-kms": "digitalbazaar/bedrock-kms#fix-index",
+    "bedrock-kms": "^5.0.0",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -42,7 +42,7 @@
     "p-map": "^4.0.0",
     "sinon": "^9.0.2",
     "uuid-random": "^1.3.2",
-    "webkms-client": "^2.3.0"
+    "webkms-client": "digitalbazaar/webkms-client#kms-client-headers"
   },
   "nyc": {
     "excludeNodeModules": false,

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-karma": "^2.1.0",
-    "bedrock-kms": "digitalbazaar/bedrock-kms#keystore-config-update",
+    "bedrock-kms": "^4.0.0",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-karma": "^2.1.0",
-    "bedrock-kms": "^4.0.0",
+    "bedrock-kms": "^4.0.1",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -19,7 +19,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-karma": "^2.1.0",
-    "bedrock-kms": "^4.0.1",
+    "bedrock-kms": "digitalbazaar/bedrock-kms#fix-index",
     "bedrock-kms-http": "file:..",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -42,7 +42,7 @@
     "p-map": "^4.0.0",
     "sinon": "^9.0.2",
     "uuid-random": "^1.3.2",
-    "webkms-client": "digitalbazaar/webkms-client#kms-client-headers"
+    "webkms-client": "^3.1.0"
   },
   "nyc": {
     "excludeNodeModules": false,

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -17,8 +17,6 @@ config['kms-http'].requireAuthentication = false;
 
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
 
-config.kms.allowedHost = config.server.host;
-
 // allow self-signed certs in test framework
 config['https-agent'].rejectUnauthorized = false;
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 const bedrock = require('bedrock');
 require('bedrock-https-agent');

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2021 Digital Bazaar, Inc. All rights reserved.
  */
 import pMap from 'p-map';
 import uuid from 'uuid-random';

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -46,7 +46,7 @@ describe('bedrock-kms-http HMAC operations', () => {
       try {
         result = await hmac.sign({data});
       } catch(e) {
-        err = err;
+        err = e;
       }
       should.not.exist(err);
       should.exist(result);


### PR DESCRIPTION
@dlongley there are a couple/few fixmes to be resolved immediately here.

### Added
- Keystore configurations may now include an optional `ipAllowList` array. If
  specified, the KMS system will only execute requests originating from IPs
  listed in `ipAllowList`. This applies to key operations for all keys in the
  keystore as well as modification of the configuration itself.